### PR TITLE
Various cleanup

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -32,6 +32,12 @@ jobs:
         run: |
           cachix watch-store -c9 -j2 asterius &
 
-      - name: test
+      - name: build
         run: |
-          nix-shell --pure --run "cd cbits_test && ./test.sh"
+          cp $(nix build --json --no-link -f nix/top.nix cbits | jq -r '.[0].outputs.cbits')/* cbits
+
+      - name: upload-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: cbits
+          path: cbits

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This is a Haskell cabal project, simply run the `libffi-wasm32`
 executable. It'll generate additional C sources in `cbits`. Then
 include stuff in `cbits` for your own usage.
 
+The generated `cbits` are also available as CI artifacts.
+
 ## How?
 
 There'll probably be a blog post or something.

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,2 @@
 packages:    .
-index-state: 2022-01-10T17:57:05Z
-constraints: aeson == 1.5.6.0
+index-state: 2022-01-20T00:00:00Z

--- a/cbits/ffi.h
+++ b/cbits/ffi.h
@@ -6,6 +6,7 @@ extern "C" {
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 typedef enum { FFI_DEFAULT_ABI } ffi_abi;
 
@@ -27,6 +28,9 @@ extern ffi_type ffi_type_sint64;
 extern ffi_type ffi_type_float;
 extern ffi_type ffi_type_double;
 extern ffi_type ffi_type_pointer;
+
+typedef uint32_t ffi_arg;
+typedef int32_t ffi_sarg;
 
 typedef struct {
   ffi_abi abi;

--- a/cbits_test/test.sh
+++ b/cbits_test/test.sh
@@ -1,11 +1,11 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -euox pipefail
+set -eu
 
 $CC call.c -o call.wasm
 
-wasmtime call.wasm
+wasmtime run --disable-cache call.wasm
 
 $CC closure.c -o closure.wasm
 
-wasmtime closure.wasm
+wasmtime run --disable-cache closure.wasm

--- a/libffi-wasm32.cabal
+++ b/libffi-wasm32.cabal
@@ -32,7 +32,7 @@ test-suite libffi-wasm32-test
   build-depends:
     , base
     , libffi-wasm32-internal
-    , sydtest
+    , tasty
 
   ghc-options:      -Wall -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:   test

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,7 +1,7 @@
 { sources ? import ./sources.nix { }
 , haskellNix ? import sources.haskell-nix { }
 , pkgs ? import haskellNix.sources.nixpkgs-unstable haskellNix.nixpkgsArgs
-, ghc ? "ghc8107"
+, ghc ? "ghc922"
 }:
 pkgs.callPackage
   ({ callPackage, haskell-nix, stdenvNoCC }:
@@ -19,7 +19,7 @@ pkgs.callPackage
       postPatch = "patchShebangs .";
       nativeBuildInputs = [
         (callPackage ./project.nix {
-          ghc = "ghc8107";
+          ghc = "ghc922";
         }).libffi-wasm32.components.tests.libffi-wasm32-test
         (callPackage "${sources.hs-nix-tools}/pkgs/wasmtime" { })
       ];

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -3,12 +3,12 @@
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
         "homepage": "https://input-output-hk.github.io/haskell.nix",
-        "owner": "TerrorJack",
+        "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "5f1857bda3f7e8f7b4e42bcffffb50e83efd90e0",
-        "sha256": "13299nwdfpvhfca0akz4ccdkc9rkpjyzmmblmx5nr9qpxfbjbvlx",
+        "rev": "eb49a3b7213470e36570f4aa1ed7a64e6d6cf160",
+        "sha256": "03k5qgcczk30vfpczv66b4dhc6xn2z5wcyzafcxgd7731rybf50r",
         "type": "tarball",
-        "url": "https://github.com/TerrorJack/haskell.nix/archive/5f1857bda3f7e8f7b4e42bcffffb50e83efd90e0.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/eb49a3b7213470e36570f4aa1ed7a64e6d6cf160.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-nix-tools": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "TerrorJack",
         "repo": "hs-nix-tools",
-        "rev": "812e5652ea2b8210fd1b800a45c2a07b95460d22",
-        "sha256": "14jyi95i334vwr6zw3pf7ikjgjrx933l4d1zkqm7xs8xpxm0vg75",
+        "rev": "1a649703eeeb66e63a8823123155c580160dc0df",
+        "sha256": "1j18vq7zk0pm4ij8xnjfd4ldad7q05qx8kp9rin4l1977a5pw89x",
         "type": "tarball",
-        "url": "https://github.com/TerrorJack/hs-nix-tools/archive/812e5652ea2b8210fd1b800a45c2a07b95460d22.tar.gz",
+        "url": "https://github.com/TerrorJack/hs-nix-tools/archive/1a649703eeeb66e63a8823123155c580160dc0df.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "wasi-sdk": {

--- a/nix/top.nix
+++ b/nix/top.nix
@@ -1,0 +1,4 @@
+{ sources ? import ./sources.nix { }
+, haskellNix ? import sources.haskell-nix { }
+, pkgs ? import haskellNix.sources.nixpkgs-unstable haskellNix.nixpkgsArgs
+}: pkgs.callPackage ./libffi.nix {}

--- a/nix/wasmtime.nix
+++ b/nix/wasmtime.nix
@@ -1,0 +1,33 @@
+{ autoPatchelfHook, fetchzip, lib, stdenv }:
+stdenv.mkDerivation rec {
+  pname = "wasmtime";
+  version = "0.35.1";
+  src = fetchzip {
+    x86_64-linux = {
+      url =
+        "https://github.com/bytecodealliance/wasmtime/releases/download/v${version}/wasmtime-v${version}-x86_64-linux.tar.xz";
+      hash =
+        "sha512-4rDy+XQy4PhYrJ9g1YsGwenD/W7eNwERSRqW5UTfR0JmT+AlMTbsQgVxgDux4cQ/LfawKUkWvRpg0H2O5Wu8fA==";
+    };
+    aarch64-linux = {
+      url =
+        "https://github.com/bytecodealliance/wasmtime/releases/download/v${version}/wasmtime-v${version}-aarch64-linux.tar.xz";
+      hash =
+        "sha512-+JqisaBj9rS+dGPhusw3FuvM1jk8ackzVsDe/yQvkh02REK1LmmEslHaPMPwBGR/FANIjpiKKPp2h55BnMK2/Q==";
+    };
+    x86_64-darwin = {
+      url =
+        "https://github.com/bytecodealliance/wasmtime/releases/download/v${version}/wasmtime-v${version}-x86_64-macos.tar.xz";
+      hash =
+        "sha512-QYcThsSVl0DRxOVMdnoHjwlWZJylqrsDDBCwuX4MLoqw6pqWzKSEAKFFn8SuOeoQRt4JFIRz2HKVJqMpZsVUeg==";
+    };
+  }.${stdenv.hostPlatform.system};
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  installPhase = ''
+    mkdir -p $out/bin
+    install -Dm755 -t $out/bin wasmtime
+  '';
+  doInstallCheck = true;
+  installCheckPhase = "$out/bin/wasmtime --version";
+  strictDeps = true;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,29 +1,20 @@
 { sources ? import ./nix/sources.nix { }
 , haskellNix ? import sources.haskell-nix { }
 , pkgs ? import haskellNix.sources.nixpkgs-unstable haskellNix.nixpkgsArgs
-, ghc ? "ghc8107"
-, buildLibFFI ? true
+, ghc ? "ghc922"
 }:
 pkgs.callPackage
   ({ callPackage, clang-tools, lib, stdenv, util-linux }:
-    let
-      libffi = callPackage ./nix/libffi.nix { };
-      wasi-sdk = import ./nix/wasi-sdk.nix { inherit sources; };
-    in
     (callPackage ./nix/project.nix { inherit ghc; }).shellFor {
       packages = ps: with ps; [ libffi-wasm32 ];
       withHoogle = true;
       nativeBuildInputs = lib.attrValues
         (import "${sources.hs-nix-tools}/nix/tools.nix" { inherit ghc; }) ++ [
         clang-tools
-        (callPackage "${sources.hs-nix-tools}/pkgs/wasmtime" { })
       ] ++ lib.optionals stdenv.isLinux [ util-linux ];
       exactDeps = true;
       shellHook = lib.optionalString stdenv.isLinux ''
         taskset -pc 0-1000 $$
-      '' + lib.optionalString buildLibFFI ''
-        export CC="${wasi-sdk}/bin/clang -std=c11 -Wall -Wextra -Oz -flto -I${libffi}/include -L${libffi}/lib -lffi"
       '';
-      WASI_SDK_PREFIX = wasi-sdk;
     })
 { }

--- a/src/LibFFI.hs
+++ b/src/LibFFI.hs
@@ -152,6 +152,7 @@ ffiCallFunc :: [(Word, FuncType)] -> Builder
 ffiCallFunc fts =
   "void ffi_call(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)\n{\nswitch (cif->encoding) {\n"
     <> mconcat [ffiCallCase i ft | (i, ft) <- fts]
+    <> "default: exit(EXIT_FAILURE);\n"
     <> "}\n}\n"
 
 ffiCallC :: [(Word, FuncType)] -> Builder
@@ -166,7 +167,7 @@ ffiPoolClosureArrDef i m =
     <> ffiPoolClosureArrName i
     <> "[0x"
     <> wordHex m
-    <> "];\n"
+    <> "];\n\n"
 
 ffiPoolClosure :: Word -> Word -> Builder
 ffiPoolClosure i j = ffiPoolClosureArrName i <> "[0x" <> wordHex j <> "]"
@@ -223,7 +224,7 @@ ffiPoolFuncDef i j FuncType {..} =
            Just _ -> "return ret;\n"
            _ -> mempty
        )
-    <> "}\n"
+    <> "}\n\n"
 
 ffiPoolFuncArrName :: Word -> Builder
 ffiPoolFuncArrName i = "ffi_pool_func_" <> wordHex i
@@ -234,11 +235,11 @@ ffiPoolFuncArrDef i m =
     <> ffiPoolFuncArrName i
     <> "[] = {"
     <> mconcat (intersperse "," [ffiPoolFuncName i j | j <- [0 .. m - 1]])
-    <> "};\n"
+    <> "};\n\n"
 
 ffiClosureFreeDef :: Builder
 ffiClosureFreeDef =
-  "void ffi_closure_free(void *c)\n{\n((ffi_closure*)c)->fun=NULL;\n}\n"
+  "void ffi_closure_free(void *c)\n{\n((ffi_closure*)c)->fun=NULL;\n}\n\n"
 
 ffiPoolAllocDef :: Builder
 ffiPoolAllocDef =
@@ -252,7 +253,7 @@ ffiPoolAllocDef =
     <> "}\n"
     <> "}\n"
     <> "return NULL;\n"
-    <> "}\n"
+    <> "}\n\n"
 
 ffiAllocPrepClosureCase :: Word -> Word -> Builder
 ffiAllocPrepClosureCase i m =


### PR DESCRIPTION
- Add missing `ffi_arg`, `ffi_sarg` in `ffi.h`
- Add empty `ffitarget.h` to make GHC happy
- `ffi_call` should panic in case of unidentified encoding
- `ffi_closure.c` should contain more line breaks
- `libffi.nix` should run the checks
- Other nix improvements
- Serve generated cbits as CI artifact